### PR TITLE
chore: add react type packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.3",
     "typescript": "~5.8.3",
     "vite": "^7.1.2"
   }


### PR DESCRIPTION
## Summary
- add `@types/react` and `@types/react-dom` to dev dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b415615a6c832bb516f67981f81df3