### PR TITLE
Add NextAuth route and role-aware API dispatcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "dev": "next dev",
+    "dev": "prisma generate && next dev",
     "build": "prisma generate && next build",
     "start": "next start",
     "postinstall": "prisma generate",

--- a/src/app/api/[...slug]/route.ts
+++ b/src/app/api/[...slug]/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { auth } from "@/lib/auth";
+
+const modelMap = {
+  products: "product",
+  businesses: "business",
+  users: "user",
+  orders: "order",
+  settings: "settings",
+  applications: "application",
+  preorders: "preorder"
+} as const;
+
+const roleMap: Record<keyof typeof modelMap, string[]> = {
+  products: ["owner", "inventory"],
+  businesses: ["owner", "manager"],
+  users: ["owner", "hr"],
+  orders: ["owner", "orders"],
+  settings: ["owner"],
+  applications: ["owner", "hr"],
+  preorders: ["owner", "inventory"]
+};
+
+type Resource = keyof typeof modelMap;
+
+async function handle(
+  req: NextRequest,
+  { params }: { params: { slug: string[] } },
+  method: string
+) {
+  const [resource, id] = params.slug || [];
+  const session = await auth();
+  if (!session) return new Response("Unauthorized", { status: 401 });
+
+  const allowed = roleMap[resource as Resource];
+  const role = (session as any).staffRole as string | null;
+  if (!allowed || !role || !allowed.includes(role))
+    return new Response("Forbidden", { status: 403 });
+
+  const modelKey = modelMap[resource as Resource];
+  if (!modelKey) return new Response("Not Found", { status: 404 });
+  const model = (prisma as any)[modelKey];
+
+  try {
+    if (method === "GET") {
+      if (id || resource === "settings") {
+        const whereId = resource === "settings" ? Number(id || 1) : id;
+        const data = await model.findUnique({ where: { id: whereId } });
+        return Response.json(data);
+      }
+      const data = await model.findMany();
+      return Response.json(data);
+    }
+
+    const body = await req.json();
+    if (method === "POST") {
+      const data = await model.create({ data: body });
+      return Response.json(data);
+    }
+    if (method === "PUT") {
+      const whereId = resource === "settings" ? Number(id || 1) : id;
+      const data = await model.update({ where: { id: whereId }, data: body });
+      return Response.json(data);
+    }
+    if (method === "DELETE") {
+      const whereId = resource === "settings" ? Number(id || 1) : id;
+      const data = await model.delete({ where: { id: whereId } });
+      return Response.json(data);
+    }
+
+    return new Response("Method Not Allowed", { status: 405 });
+  } catch (e) {
+    console.error(e);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+}
+
+export function GET(req: NextRequest, ctx: { params: { slug: string[] } }) {
+  return handle(req, ctx, "GET");
+}
+export function POST(req: NextRequest, ctx: { params: { slug: string[] } }) {
+  return handle(req, ctx, "POST");
+}
+export function PUT(req: NextRequest, ctx: { params: { slug: string[] } }) {
+  return handle(req, ctx, "PUT");
+}
+export function DELETE(req: NextRequest, ctx: { params: { slug: string[] } }) {
+  return handle(req, ctx, "DELETE");
+}

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/lib/auth";
+
+export const { GET, POST } = handlers;


### PR DESCRIPTION
## Summary
- add NextAuth auth route wired to existing credentials configuration
- implement catch-all API dispatcher with Prisma CRUD and session-based role checks
- ensure dev script generates Prisma client before Next.js dev

## Testing
- `npm test` *(fails: Missing script)*
- `DATABASE_URL='file:dev.db' npm run build` *(fails: prisma: not found)*
- `npm install` *(fails: 403 Forbidden for @prisma/client)*

------
https://chatgpt.com/codex/tasks/task_e_68b48dadb7f8832b94f8bfaa0c975d44