### PR TITLE
Add migration, seed script, and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,34 @@
-HEJ
-// -------------------- Demo Seed Data --------------------
-const SEED_PRODUCTS: Product[] = [ ... ];
-const SEED_BUSINESS_USERS: BusinessUser[] = [ ... ];
-const SEED_ADMIN = { username: "admin", password: "admin123" };
+# Pawnshop
+
+## Environment
+
+Create a `.env` file with your database connection string:
+
+```
+DATABASE_URL="postgresql://user:password@localhost:5432/pawnshop"
+```
+
+## Database
+
+Generate and apply migrations
+
+```
+npm run db:migrate
+```
+
+Seed the default admin user and settings
+
+```
+npm run db:seed
+```
+
+## Vercel deployment
+
+1. Provision a PostgreSQL database (for example Neon or Supabase).
+2. In the Vercel project settings add a `DATABASE_URL` environment variable with the connection string.
+3. Trigger the migration and seed on Vercel:
+   ```
+   vercel run npm run db:migrate
+   vercel run npm run db:seed
+   ```
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "prisma generate && next build",
     "start": "next start",
     "postinstall": "prisma generate",
-    "seed": "tsx prisma/seed.ts"
+    "db:migrate": "prisma migrate dev",
+    "db:seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.16.2",

--- a/prisma/migrations/00000000000000_init/migration.sql
+++ b/prisma/migrations/00000000000000_init/migration.sql
@@ -1,0 +1,143 @@
+-- CreateEnum
+CREATE TYPE "StaffRole" AS ENUM ('owner', 'hr', 'manager', 'inventory', 'orders', 'viewer');
+
+-- CreateEnum
+CREATE TYPE "BizRole" AS ENUM ('owner', 'manager', 'employee');
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "username" TEXT NOT NULL,
+    "displayName" TEXT NOT NULL,
+    "email" TEXT,
+    "hashedPassword" TEXT NOT NULL,
+    "mustChangePassword" BOOLEAN NOT NULL DEFAULT false,
+    "stateId" TEXT,
+    "mustAddStateId" BOOLEAN NOT NULL DEFAULT true,
+    "staffRole" "StaffRole",
+    "bizRole" "BizRole",
+    "businessId" TEXT,
+    "emailVerified" TIMESTAMP(3),
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Business" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "name" TEXT NOT NULL,
+    "discountPct" INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT "Business_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Product" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "publicPrice" INTEGER NOT NULL,
+    "businessPrice" INTEGER NOT NULL,
+    "stock" INTEGER NOT NULL DEFAULT 0,
+    "image" TEXT,
+    "cardSize" TEXT,
+    CONSTRAINT "Product_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Order" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "businessId" TEXT NOT NULL,
+    "placedById" TEXT NOT NULL,
+    "delivery" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "total" INTEGER NOT NULL,
+    "pickupCode" TEXT,
+    "invoicePaid" BOOLEAN NOT NULL DEFAULT false,
+    CONSTRAINT "Order_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrderItem" (
+    "id" TEXT NOT NULL,
+    "orderId" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "qty" INTEGER NOT NULL,
+    "unitPrice" INTEGER NOT NULL,
+    CONSTRAINT "OrderItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Preorder" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "businessId" TEXT NOT NULL,
+    "requestedById" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'pending',
+    "note" TEXT,
+    CONSTRAINT "Preorder_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PreorderItem" (
+    "id" TEXT NOT NULL,
+    "preorderId" TEXT NOT NULL,
+    "productId" TEXT NOT NULL,
+    "qty" INTEGER NOT NULL,
+    CONSTRAINT "PreorderItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Application" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "inGameFullName" TEXT NOT NULL,
+    "contact" TEXT NOT NULL,
+    "phone" TEXT,
+    "stateId" TEXT,
+    "region" TEXT NOT NULL,
+    "about" TEXT NOT NULL,
+    "moreThan5Hours" BOOLEAN NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'new',
+    CONSTRAINT "Application_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Settings" (
+    "id" INTEGER NOT NULL DEFAULT 1,
+    "bgUrl" TEXT,
+    "doNotBuyJson" TEXT,
+    "payoutPct" INTEGER NOT NULL DEFAULT 60,
+    "feePct" INTEGER NOT NULL DEFAULT 0,
+    "feeFlat" INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT "Settings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_username_key" ON "User"("username");
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "Business_name_key" ON "Business"("name");
+
+CREATE INDEX "User_businessId_idx" ON "User"("businessId");
+CREATE INDEX "Order_businessId_idx" ON "Order"("businessId");
+CREATE INDEX "Order_placedById_idx" ON "Order"("placedById");
+CREATE INDEX "OrderItem_orderId_idx" ON "OrderItem"("orderId");
+CREATE INDEX "OrderItem_productId_idx" ON "OrderItem"("productId");
+CREATE INDEX "Preorder_businessId_idx" ON "Preorder"("businessId");
+CREATE INDEX "Preorder_requestedById_idx" ON "Preorder"("requestedById");
+CREATE INDEX "PreorderItem_preorderId_idx" ON "PreorderItem"("preorderId");
+CREATE INDEX "PreorderItem_productId_idx" ON "PreorderItem"("productId");
+
+-- AddForeignKey
+ALTER TABLE "User" ADD CONSTRAINT "User_businessId_fkey" FOREIGN KEY ("businessId") REFERENCES "Business"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "Order" ADD CONSTRAINT "Order_businessId_fkey" FOREIGN KEY ("businessId") REFERENCES "Business"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Order" ADD CONSTRAINT "Order_placedById_fkey" FOREIGN KEY ("placedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "OrderItem" ADD CONSTRAINT "OrderItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Preorder" ADD CONSTRAINT "Preorder_businessId_fkey" FOREIGN KEY ("businessId") REFERENCES "Business"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Preorder" ADD CONSTRAINT "Preorder_requestedById_fkey" FOREIGN KEY ("requestedById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "PreorderItem" ADD CONSTRAINT "PreorderItem_preorderId_fkey" FOREIGN KEY ("preorderId") REFERENCES "Preorder"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "PreorderItem" ADD CONSTRAINT "PreorderItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,12 +1,13 @@
 import { PrismaClient } from "@prisma/client";
 import bcrypt from "bcryptjs";
+
 const prisma = new PrismaClient();
 
 async function main() {
   await prisma.settings.upsert({
     where: { id: 1 },
     update: {},
-    create: { id: 1, payoutPct: 60, feePct: 0, feeFlat: 0 }
+    create: { id: 1, payoutPct: 60, feePct: 0, feeFlat: 0 },
   });
 
   const admin = await prisma.user.findUnique({ where: { username: "admin" } });
@@ -20,12 +21,21 @@ async function main() {
         staffRole: "owner",
         mustChangePassword: true,
         mustAddStateId: false,
-        stateId: "ADMIN"
-      }
+        stateId: "ADMIN",
+      },
     });
     console.log("Seeded admin / 1234");
   } else {
     console.log("Admin exists");
   }
 }
-main().finally(() => prisma.$disconnect());
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+


### PR DESCRIPTION
## Summary
- add initial Prisma migration and seed default admin/settings
- expose `db:migrate` and `db:seed` npm scripts
- document environment setup and Vercel deployment

## Testing
- `npx prisma migrate dev --name init --create-only` *(fails: 403 Forbidden from npm registry)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: prisma: not found)*
- `npm run lint` *(fails: Missing script "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68b48daf6e54832bb9e3b7f4c47e3d6d