### PR TITLE
Add setup redirects and state update endpoints

### DIFF
--- a/src/app/api/[...route]/route.ts
+++ b/src/app/api/[...route]/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { auth } from "../../../lib/auth";
+import { prisma } from "../../../lib/prisma";
+import bcrypt from "bcryptjs";
+
+export async function POST(req: Request, { params }: { params: { route: string[] } }) {
+  const path = (params.route || []).join("/");
+  const session = await auth();
+  if (!session || !(session as any).username) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  switch (path) {
+    case "me/change-password": {
+      const { newPassword } = await req.json();
+      const hashed = await bcrypt.hash(newPassword, 10);
+      await prisma.user.update({
+        where: { username: (session as any).username },
+        data: { hashedPassword: hashed, mustChangePassword: false }
+      });
+      await session.update?.({ mustChangePassword: false });
+      return NextResponse.json({ ok: true });
+    }
+    case "me/set-stateid": {
+      const { stateId } = await req.json();
+      await prisma.user.update({
+        where: { username: (session as any).username },
+        data: { stateId, mustAddStateId: false }
+      });
+      await session.update?.({ mustAddStateId: false, stateId });
+      return NextResponse.json({ ok: true });
+    }
+    default:
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -36,6 +36,11 @@ export const authConfig: NextAuthConfig = {
   session: { strategy: "jwt" },
   pages: { signIn: "/login" },
   callbacks: {
+    async signIn({ user }) {
+      if ((user as any).mustChangePassword) return "/setup/change-password";
+      if ((user as any).mustAddStateId) return "/setup/set-stateid";
+      return true;
+    },
     async jwt({ token, user }) {
       if (user) {
         token.staffRole = (user as any).staffRole || null;


### PR DESCRIPTION
## Summary
- Redirect new logins to setup flows when password or state ID is required
- Add API endpoints for password change and state ID update that clear session flags

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: prisma not found)

------
https://chatgpt.com/codex/tasks/task_e_68b48daf7a38832bba386c90c25f1f73