### PR TITLE
feat: add portal sections with top bar navigation

### DIFF
--- a/src/app/(portal)/business/checkout/page.tsx
+++ b/src/app/(portal)/business/checkout/page.tsx
@@ -1,0 +1,3 @@
+export default function CheckoutPage() {
+  return <h1 className="text-xl font-bold">Checkout</h1>;
+}

--- a/src/app/(portal)/business/inventory/page.tsx
+++ b/src/app/(portal)/business/inventory/page.tsx
@@ -1,0 +1,3 @@
+export default function InventoryPage() {
+  return <h1 className="text-xl font-bold">Inventory</h1>;
+}

--- a/src/app/(portal)/business/layout.tsx
+++ b/src/app/(portal)/business/layout.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link';
+import React from 'react';
+
+const tabs = [
+  { href: '/business/inventory', label: 'Inventory' },
+  { href: '/business/checkout', label: 'Checkout' },
+  { href: '/business/pre-orders', label: 'Pre-Orders' },
+  { href: '/business/users', label: 'Users' },
+  { href: '/business/order-tracking', label: 'Order Tracking' },
+];
+
+export default function BusinessLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <nav className="flex gap-4 border-b pb-2 mb-4">
+        {tabs.map((t) => (
+          <Link key={t.href} href={t.href} className="hover:underline">
+            {t.label}
+          </Link>
+        ))}
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/src/app/(portal)/business/order-tracking/page.tsx
+++ b/src/app/(portal)/business/order-tracking/page.tsx
@@ -1,0 +1,3 @@
+export default function OrderTrackingPage() {
+  return <h1 className="text-xl font-bold">Order Tracking</h1>;
+}

--- a/src/app/(portal)/business/page.tsx
+++ b/src/app/(portal)/business/page.tsx
@@ -1,0 +1,8 @@
+export default function BusinessHome() {
+  return (
+    <div>
+      <h1 className="text-xl font-bold">Business Portal</h1>
+      <p>Select a tab above to get started.</p>
+    </div>
+  );
+}

--- a/src/app/(portal)/business/pre-orders/page.tsx
+++ b/src/app/(portal)/business/pre-orders/page.tsx
@@ -1,0 +1,3 @@
+export default function PreOrdersPage() {
+  return <h1 className="text-xl font-bold">Pre-Orders</h1>;
+}

--- a/src/app/(portal)/business/users/page.tsx
+++ b/src/app/(portal)/business/users/page.tsx
@@ -1,0 +1,3 @@
+export default function BusinessUsersPage() {
+  return <h1 className="text-xl font-bold">Users</h1>;
+}

--- a/src/app/(portal)/layout.tsx
+++ b/src/app/(portal)/layout.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import TopBar from '../../components/TopBar';
+
+export default function PortalLayout({ children }: { children: React.ReactNode }) {
+  // Placeholder values; in real app these would come from auth/session
+  const username = 'Demo User';
+  const stateId = 'STATE-12345';
+
+  return (
+    <div>
+      <TopBar username={username} stateId={stateId} />
+      <main className="p-4">{children}</main>
+    </div>
+  );
+}

--- a/src/app/(portal)/staff/businesses/page.tsx
+++ b/src/app/(portal)/staff/businesses/page.tsx
@@ -1,0 +1,3 @@
+export default function StaffBusinessesPage() {
+  return <h1 className="text-xl font-bold">Businesses</h1>;
+}

--- a/src/app/(portal)/staff/layout.tsx
+++ b/src/app/(portal)/staff/layout.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link';
+import React from 'react';
+
+const tabs = [
+  { href: '/staff/products', label: 'Products' },
+  { href: '/staff/orders', label: 'Orders' },
+  { href: '/staff/businesses', label: 'Businesses' },
+  { href: '/staff/users', label: 'Users' },
+  { href: '/staff/settings', label: 'Settings' },
+  { href: '/staff/purchase-calculator', label: 'Purchase Calculator' },
+];
+
+export default function StaffLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div>
+      <nav className="flex gap-4 border-b pb-2 mb-4">
+        {tabs.map((t) => (
+          <Link key={t.href} href={t.href} className="hover:underline">
+            {t.label}
+          </Link>
+        ))}
+      </nav>
+      {children}
+    </div>
+  );
+}

--- a/src/app/(portal)/staff/orders/page.tsx
+++ b/src/app/(portal)/staff/orders/page.tsx
@@ -1,0 +1,3 @@
+export default function StaffOrdersPage() {
+  return <h1 className="text-xl font-bold">Orders</h1>;
+}

--- a/src/app/(portal)/staff/page.tsx
+++ b/src/app/(portal)/staff/page.tsx
@@ -1,0 +1,8 @@
+export default function StaffHome() {
+  return (
+    <div>
+      <h1 className="text-xl font-bold">Staff Portal</h1>
+      <p>Select a tab above to manage the system.</p>
+    </div>
+  );
+}

--- a/src/app/(portal)/staff/products/page.tsx
+++ b/src/app/(portal)/staff/products/page.tsx
@@ -1,0 +1,3 @@
+export default function StaffProductsPage() {
+  return <h1 className="text-xl font-bold">Products</h1>;
+}

--- a/src/app/(portal)/staff/purchase-calculator/page.tsx
+++ b/src/app/(portal)/staff/purchase-calculator/page.tsx
@@ -1,0 +1,3 @@
+export default function PurchaseCalculatorPage() {
+  return <h1 className="text-xl font-bold">Purchase Calculator</h1>;
+}

--- a/src/app/(portal)/staff/settings/page.tsx
+++ b/src/app/(portal)/staff/settings/page.tsx
@@ -1,0 +1,3 @@
+export default function StaffSettingsPage() {
+  return <h1 className="text-xl font-bold">Settings</h1>;
+}

--- a/src/app/(portal)/staff/users/page.tsx
+++ b/src/app/(portal)/staff/users/page.tsx
@@ -1,0 +1,3 @@
+export default function StaffUsersPage() {
+  return <h1 className="text-xl font-bold">Users</h1>;
+}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import Link from 'next/link';
+import React from 'react';
+
+interface TopBarProps {
+  username: string;
+  stateId: string;
+}
+
+export default function TopBar({ username, stateId }: TopBarProps) {
+  return (
+    <header className="flex items-center justify-between border-b p-4">
+      <div className="font-semibold">{username}</div>
+      <div className="text-sm text-gray-600">State ID: {stateId}</div>
+      <div>
+        <Link href="/account" className="underline">
+          Account Settings
+        </Link>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add top bar with username, state ID, and account settings
- scaffold business pages: inventory, checkout, pre-orders, users, order tracking
- scaffold staff pages: products, orders, businesses, users, settings, purchase calculator
- add navigation layouts using Next.js routing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: prisma: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b48db0d6fc832b8dd9d3b2315cac1d