### PR TITLE
feat: add product list and job application

### DIFF
--- a/src/app/api/applications/route.ts
+++ b/src/app/api/applications/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  const application = await prisma.application.create({ data });
+  return NextResponse.json(application);
+}

--- a/src/app/apply/page.tsx
+++ b/src/app/apply/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+
+interface FormState {
+  inGameFullName: string;
+  contact: string;
+  phone: string;
+  stateId: string;
+  region: string;
+  about: string;
+  moreThan5Hours: boolean;
+}
+
+export default function ApplyPage() {
+  const [form, setForm] = useState<FormState>({
+    inGameFullName: "",
+    contact: "",
+    phone: "",
+    stateId: "",
+    region: "",
+    about: "",
+    moreThan5Hours: false
+  });
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value, type, checked } = e.target as HTMLInputElement;
+    setForm((f) => ({ ...f, [name]: type === "checkbox" ? checked : value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch("/api/applications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(form)
+    });
+    setSubmitted(true);
+  };
+
+  if (submitted) return <p className="p-4">Thank you for applying!</p>;
+
+  return (
+    <form onSubmit={handleSubmit} className="mx-auto max-w-md space-y-4 p-4">
+      <input
+        required
+        name="inGameFullName"
+        placeholder="In-Game Full Name"
+        value={form.inGameFullName}
+        onChange={handleChange}
+        className="w-full rounded border p-2"
+      />
+      <input
+        required
+        name="contact"
+        placeholder="Discord or Contact"
+        value={form.contact}
+        onChange={handleChange}
+        className="w-full rounded border p-2"
+      />
+      <input
+        name="phone"
+        placeholder="Phone"
+        value={form.phone}
+        onChange={handleChange}
+        className="w-full rounded border p-2"
+      />
+      <input
+        name="stateId"
+        placeholder="State ID"
+        value={form.stateId}
+        onChange={handleChange}
+        className="w-full rounded border p-2"
+      />
+      <input
+        required
+        name="region"
+        placeholder="Region"
+        value={form.region}
+        onChange={handleChange}
+        className="w-full rounded border p-2"
+      />
+      <textarea
+        required
+        name="about"
+        placeholder="Tell us about yourself"
+        value={form.about}
+        onChange={handleChange}
+        className="w-full rounded border p-2"
+      />
+      <label className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          name="moreThan5Hours"
+          checked={form.moreThan5Hours}
+          onChange={handleChange}
+        />
+        <span>Can play more than 5 hours weekly</span>
+      </label>
+      <button type="submit" className="rounded bg-green-600 px-4 py-2 text-white">
+        Submit
+      </button>
+    </form>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,23 @@
+import "./globals.css";
+import { prisma } from "@/lib/prisma";
+import ThemeToggle from "@/components/ThemeToggle";
+
+export const metadata = { title: "Pawnshop" };
+
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const settings = await prisma.settings.findFirst();
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen">
+        {settings?.bgUrl && (
+          <div
+            className="fixed inset-0 -z-10 bg-cover bg-center animate-pulse"
+            style={{ backgroundImage: `url(${settings.bgUrl})` }}
+          />
+        )}
+        <ThemeToggle />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,25 @@
+import { prisma } from "@/lib/prisma";
+import Link from "next/link";
+
+export default async function HomePage() {
+  const products = await prisma.product.findMany({ orderBy: { createdAt: "desc" } });
+  return (
+    <main className="p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Products</h1>
+      <ul className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {products.map((p) => (
+          <li key={p.id} className="border rounded p-4 bg-white/80 dark:bg-gray-800/80">
+            <div className="font-semibold">{p.name}</div>
+            <div>${(p.publicPrice / 100).toFixed(2)}</div>
+          </li>
+        ))}
+      </ul>
+      <Link
+        href="/apply"
+        className="inline-block rounded bg-blue-600 px-4 py-2 text-white"
+      >
+        Apply for Job
+      </Link>
+    </main>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (dark) root.classList.add("dark");
+    else root.classList.remove("dark");
+  }, [dark]);
+
+  return (
+    <button
+      type="button"
+      onClick={() => setDark(!dark)}
+      className="fixed top-4 right-4 z-20 rounded border px-3 py-1 text-sm bg-white/80 dark:bg-gray-800/80"
+    >
+      {dark ? "Light" : "Dark"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- list products with public price and link to application form
- add application form and API endpoint to save submissions
- add theme toggle and settings-driven animated background

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: prisma: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b48db17930832b927243761463175e