### PR TITLE
feat: add order and preorder APIs with status timeline

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -742,8 +742,13 @@ function BusinessPortal({
                   <div className="font-medium">Order #{o.id}</div>
                   <div className="text-sm text-gray-600">{new Date(o.createdAt).toLocaleString()}</div>
                 </div>
-                <div className="text-sm text-gray-600 dark:text-neutral-400">
-                  Status: <b>{prettyStatus(o.status)}</b> • {o.delivery === "pickup" ? (o.pickupCode ? `Pickup code: ${o.pickupCode}` : "Pickup") : "Delivery"}
+                <StatusTimeline status={o.status} />
+                <div className="mt-1 text-sm text-gray-600 dark:text-neutral-400">
+                  {o.delivery === "pickup"
+                    ? o.pickupCode
+                      ? `Pickup code: ${o.pickupCode}`
+                      : "Pickup"
+                    : "Delivery"}
                 </div>
                 <div className="mt-1 font-semibold">{money(o.total)}</div>
               </div>
@@ -1058,6 +1063,7 @@ function OrdersTab({
                       Paid
                     </label>
                   </div>
+                  <StatusTimeline status={o.status} />
                   {o.pickupCode && (
                     <div className="rounded-xl border border-dashed border-gray-300 p-2 text-sm dark:border-neutral-700">
                       Pickup code: <b>{o.pickupCode}</b>
@@ -1398,6 +1404,46 @@ function prettyStatus(s: FulfillmentStatus) {
     default:
       return s;
   }
+}
+
+const ORDER_FLOW: FulfillmentStatus[] = [
+  "placed",
+  "accepted",
+  "processing",
+  "out_for_delivery",
+  "ready_for_pickup",
+  "fulfilled",
+];
+
+function StatusTimeline({
+  status,
+}: {
+  status: FulfillmentStatus;
+}) {
+  return (
+    <ol className="flex items-center text-xs">
+      {ORDER_FLOW.map((s, i) => {
+        const activeIndex = ORDER_FLOW.indexOf(status);
+        const done = i < activeIndex;
+        const active = i === activeIndex;
+        return (
+          <li key={s} className="flex-1">
+            <div
+              className={`border-b-2 p-1 text-center ${
+                active
+                  ? "border-blue-500 font-semibold"
+                  : done
+                  ? "border-green-500 text-green-600"
+                  : "border-gray-300 text-gray-400"
+              }`}
+            >
+              {prettyStatus(s)}
+            </div>
+          </li>
+        );
+      })}
+    </ol>
+  );
 }
 
 /* ================== Apply Page ================== */

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { z } from "zod";
+
+const PatchSchema = z.object({
+  status: z.string().optional(),
+  invoicePaid: z.boolean().optional(),
+});
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const data = PatchSchema.parse(await req.json());
+  const order = await prisma.order.update({
+    where: { id: params.id },
+    data: {
+      status: data.status,
+      invoicePaid: data.invoicePaid,
+    },
+    include: { items: true },
+  });
+  return NextResponse.json(order);
+}

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { z } from "zod";
+
+const OrderItemSchema = z.object({
+  productId: z.string(),
+  qty: z.number().int().positive(),
+});
+
+const OrderSchema = z.object({
+  businessId: z.string(),
+  placedById: z.string(),
+  delivery: z.enum(["pickup", "delivery"]),
+  items: z.array(OrderItemSchema).min(1),
+});
+
+export async function POST(req: Request) {
+  const data = OrderSchema.parse(await req.json());
+  const pickupCode =
+    data.delivery === "pickup"
+      ? String(Math.floor(100000 + Math.random() * 900000))
+      : null;
+
+  const order = await prisma.$transaction(async (tx) => {
+    let total = 0;
+    const items: { productId: string; qty: number; unitPrice: number }[] = [];
+    for (const it of data.items) {
+      const product = await tx.product.findUnique({
+        where: { id: it.productId },
+        select: { stock: true, businessPrice: true },
+      });
+      if (!product || product.stock < it.qty) {
+        throw new Error("INSUFFICIENT_STOCK");
+      }
+      await tx.product.update({
+        where: { id: it.productId },
+        data: { stock: { decrement: it.qty } },
+      });
+      total += product.businessPrice * it.qty;
+      items.push({ productId: it.productId, qty: it.qty, unitPrice: product.businessPrice });
+    }
+
+    return tx.order.create({
+      data: {
+        businessId: data.businessId,
+        placedById: data.placedById,
+        delivery: data.delivery,
+        status: "placed",
+        total,
+        pickupCode: pickupCode || undefined,
+        items: { create: items },
+      },
+      include: { items: true },
+    });
+  });
+
+  return NextResponse.json(order, { status: 201 });
+}

--- a/src/app/api/preorders/[id]/approve/route.ts
+++ b/src/app/api/preorders/[id]/approve/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const preorder = await prisma.preorder.findUnique({
+    where: { id: params.id },
+    include: { items: true },
+  });
+  if (!preorder) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  const order = await prisma.$transaction(async (tx) => {
+    let total = 0;
+    const orderItems: { productId: string; qty: number; unitPrice: number }[] = [];
+    for (const it of preorder.items) {
+      const product = await tx.product.findUnique({
+        where: { id: it.productId },
+        select: { stock: true, businessPrice: true },
+      });
+      if (!product || product.stock < it.qty) {
+        throw new Error("INSUFFICIENT_STOCK");
+      }
+      await tx.product.update({
+        where: { id: it.productId },
+        data: { stock: { decrement: it.qty } },
+      });
+      total += product.businessPrice * it.qty;
+      orderItems.push({
+        productId: it.productId,
+        qty: it.qty,
+        unitPrice: product.businessPrice,
+      });
+    }
+    const order = await tx.order.create({
+      data: {
+        businessId: preorder.businessId,
+        placedById: preorder.requestedById,
+        delivery: "pickup",
+        status: "placed",
+        total,
+        items: { create: orderItems },
+      },
+      include: { items: true },
+    });
+    await tx.preorder.update({
+      where: { id: preorder.id },
+      data: { status: "approved" },
+    });
+    return order;
+  });
+  return NextResponse.json(order);
+}

--- a/src/app/api/preorders/[id]/deny/route.ts
+++ b/src/app/api/preorders/[id]/deny/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const preorder = await prisma.preorder.update({
+    where: { id: params.id },
+    data: { status: "denied" },
+    include: { items: true },
+  });
+  return NextResponse.json(preorder);
+}

--- a/src/app/api/preorders/route.ts
+++ b/src/app/api/preorders/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { z } from "zod";
+
+const ItemSchema = z.object({
+  productId: z.string(),
+  qty: z.number().int().positive(),
+});
+
+const PreorderSchema = z.object({
+  businessId: z.string(),
+  requestedById: z.string(),
+  note: z.string().optional(),
+  items: z.array(ItemSchema).min(1),
+});
+
+export async function POST(req: Request) {
+  const data = PreorderSchema.parse(await req.json());
+  const preorder = await prisma.preorder.create({
+    data: {
+      businessId: data.businessId,
+      requestedById: data.requestedById,
+      note: data.note,
+      items: { create: data.items },
+    },
+    include: { items: true },
+  });
+  return NextResponse.json(preorder, { status: 201 });
+}


### PR DESCRIPTION
## Summary
- add order API to create orders, reserve stock, and generate pickup codes
- support updating order status and invoice flags
- implement preorder APIs including approval that converts to orders
- show order progress timeline and pickup codes in portals

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: prisma: not found)
- `npm install` (fails: 403 Forbidden @prisma/client)


------
https://chatgpt.com/codex/tasks/task_e_68b48db3839c832b9c768d3d02e827e5