### PR TITLE
Use session data in portal layout and add account page

### DIFF
--- a/src/app/(portal)/layout.tsx
+++ b/src/app/(portal)/layout.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import TopBar from '../../components/TopBar';
+import { auth } from '../../lib/auth';
 
-export default function PortalLayout({ children }: { children: React.ReactNode }) {
-  // Placeholder values; in real app these would come from auth/session
-  const username = 'Demo User';
-  const stateId = 'STATE-12345';
+export default async function PortalLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await auth();
+  const username = (session as any)?.username ?? session?.user?.name ?? null;
+  const stateId = (session as any)?.stateId ?? null;
 
   return (
     <div>

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { auth } from '../../lib/auth';
+
+export default async function AccountPage() {
+  const session = await auth();
+
+  if (!session) {
+    return (
+      <div className="p-4">
+        <h1 className="text-xl font-semibold mb-4">Account Settings</h1>
+        <p>You must be signed in to view this page.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-semibold mb-4">Account Settings</h1>
+      <p className="mb-2">Username: {(session as any).username || session.user?.name}</p>
+      <p>State ID: {(session as any).stateId || 'N/A'}</p>
+    </div>
+  );
+}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -4,15 +4,18 @@ import Link from 'next/link';
 import React from 'react';
 
 interface TopBarProps {
-  username: string;
-  stateId: string;
+  username?: string | null;
+  stateId?: string | null;
 }
 
 export default function TopBar({ username, stateId }: TopBarProps) {
+  const displayName = username || 'Guest';
+  const displayStateId = stateId || 'N/A';
+
   return (
     <header className="flex items-center justify-between border-b p-4">
-      <div className="font-semibold">{username}</div>
-      <div className="text-sm text-gray-600">State ID: {stateId}</div>
+      <div className="font-semibold">{displayName}</div>
+      <div className="text-sm text-gray-600">State ID: {displayStateId}</div>
       <div>
         <Link href="/account" className="underline">
           Account Settings


### PR DESCRIPTION
## Summary
- Pull username and state ID from NextAuth session in portal layout
- Add `/account` route to view basic session info
- Make `TopBar` robust when session is missing with fallback values

## Testing
- ⚠️ `npm run build` *(failed: prisma not found; `npm install` returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a39c470c832b938bafcbe2268a46