### PR TITLE
Add login and home pages to app router

### DIFF
--- a/src/app/(portal)/account/page.tsx
+++ b/src/app/(portal)/account/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { auth } from '../../lib/auth';
+import { auth } from '../../../lib/auth';
 
 export default async function AccountPage() {
   const session = await auth();

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import '../index.css';
+import './globals.css';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import { signIn } from 'next-auth/react';
+
+export default function LoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    const res = await signIn('credentials', {
+      username,
+      password,
+      redirect: true,
+      callbackUrl: '/account',
+    });
+    if (res && res.error) {
+      setError(res.error);
+    }
+  }
+
+  return (
+    <div className="p-4 max-w-sm mx-auto">
+      <h1 className="text-xl font-semibold mb-4">Sign in</h1>
+      {error && <p className="mb-2 text-red-600">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Username"
+          className="w-full border px-2 py-1"
+          required
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="w-full border px-2 py-1"
+          required
+        />
+        <button
+          type="submit"
+          className="w-full bg-blue-600 text-white py-1"
+        >
+          Sign in
+        </button>
+      </form>
+    </div>
+  );
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { auth } from '../lib/auth';
+
+export default async function HomePage() {
+  const session = await auth();
+  const username = (session as any)?.username || session?.user?.name;
+
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-semibold mb-4">Pawnshop Portal</h1>
+      {session ? (
+        <p>
+          Welcome back, {username}. Visit your{' '}
+          <Link href="/account" className="underline">
+            account settings
+          </Link>
+          .
+        </p>
+      ) : (
+        <p>
+          <Link href="/login" className="underline">
+            Sign in
+          </Link>{' '}
+          to continue.
+        </p>
+      )}
+    </main>
+  );
+}
+

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import React from 'react';
+import { signOut } from 'next-auth/react';
 
 interface TopBarProps {
   username?: string | null;
@@ -16,10 +17,13 @@ export default function TopBar({ username, stateId }: TopBarProps) {
     <header className="flex items-center justify-between border-b p-4">
       <div className="font-semibold">{displayName}</div>
       <div className="text-sm text-gray-600">State ID: {displayStateId}</div>
-      <div>
+      <div className="flex items-center gap-4">
         <Link href="/account" className="underline">
           Account Settings
         </Link>
+        <button onClick={() => signOut()} className="underline">
+          Sign out
+        </button>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- fix global CSS import and add Tailwind globals
- add credential-based login page and simple landing page
- move account page under portal layout and add sign out button

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: sh: 1: prisma: not found)


------
https://chatgpt.com/codex/tasks/task_e_68b4a6a3dc78832b8a86424b4b150a0c