### PR TITLE
Specify Prisma schema path for generate

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "dev": "prisma generate && next dev",
-    "build": "prisma generate && next build",
+    "dev": "prisma generate --schema ./prisma/schema.prisma && next dev",
+    "build": "prisma generate --schema ./prisma/schema.prisma && next build",
     "start": "next start",
-    "postinstall": "prisma generate",
+    "postinstall": "prisma generate --schema ./prisma/schema.prisma",
     "seed": "tsx prisma/seed.ts"
+  },
+  "prisma": {
+    "schema": "./prisma/schema.prisma"
   },
   "dependencies": {
     "@prisma/client": "^5.16.2",


### PR DESCRIPTION
## Summary
- ensure prisma CLI always uses explicit schema path
- configure package.json with prisma schema location

## Testing
- `npm run build` *(fails: prisma: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4abcdce90832b993d1cc1c96ebd0c