### PR TITLE
fix prisma schema syntax

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,8 +1,26 @@
-generator client { provider = "prisma-client-js" }
-datasource db { provider = "postgresql"; url = env("DATABASE_URL") }
+generator client {
+  provider = "prisma-client-js"
+}
 
-enum StaffRole { owner hr manager inventory orders viewer }
-enum BizRole { owner manager employee }
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum StaffRole {
+  owner
+  hr
+  manager
+  inventory
+  orders
+  viewer
+}
+
+enum BizRole {
+  owner
+  manager
+  employee
+}
 
 model User {
   id                 String   @id @default(cuid())


### PR DESCRIPTION
## Summary
- format Prisma generator and datasource blocks
- expand enum definitions for StaffRole and BizRole

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: prisma: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4ae165744832ba3e957a180c962bf